### PR TITLE
Fix/change language with format

### DIFF
--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -1099,6 +1099,10 @@ var DatePicker = snippet.defineClass(/** @lends DatePicker.prototype */{
         return this._calendar;
     },
 
+    getLocaleText: function() {
+        return localeTexts[this._language] || localeTexts[DEFAULT_LANGUAGE_TYPE];
+    },
+
     /**
      * Set input element
      * @param {string|jQuery|HTMLElement} element - Input element
@@ -1108,7 +1112,7 @@ var DatePicker = snippet.defineClass(/** @lends DatePicker.prototype */{
      */
     setInput: function(element, options) {
         var prev = this._datepickerInput;
-        var localeText = localeTexts[this._language] || localeTexts[DEFAULT_LANGUAGE_TYPE];
+        var localeText = this.getLocaleText();
         var prevFormat;
         options = options || {};
 
@@ -1232,6 +1236,9 @@ var DatePicker = snippet.defineClass(/** @lends DatePicker.prototype */{
     changeLanguage: function(language) {
         this._language = language;
         this._calendar.changeLanguage(this._language);
+        this._datepickerInput.changeLocaleTitles(this.getLocaleText().titles);
+        this.setDateFormat(this._datepickerInput.getFormat());
+
         if (this._timepicker) {
             this._timepicker.changeLanguage(this._language);
         }

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -1099,6 +1099,10 @@ var DatePicker = snippet.defineClass(/** @lends DatePicker.prototype */{
         return this._calendar;
     },
 
+    /**
+     * Returns locale text object
+     * @returns {object}
+     */
     getLocaleText: function() {
         return localeTexts[this._language] || localeTexts[DEFAULT_LANGUAGE_TYPE];
     },

--- a/src/js/datepicker/input.js
+++ b/src/js/datepicker/input.js
@@ -57,6 +57,10 @@ var DatePickerInput = snippet.defineClass(/** @lends DatePickerInput.prototype *
         this._setEvents();
     },
 
+    /**
+     * Change locale titles
+     * @param {object} titles - locale text in format
+     */
     changeLocaleTitles: function(titles) {
         this._titles = titles;
     },

--- a/src/js/datepicker/input.js
+++ b/src/js/datepicker/input.js
@@ -57,6 +57,10 @@ var DatePickerInput = snippet.defineClass(/** @lends DatePickerInput.prototype *
         this._setEvents();
     },
 
+    changeLocaleTitles: function(titles) {
+        this._titles = titles;
+    },
+
     /**
      * Set input 'click', 'change' event
      * @private

--- a/test/datepicker/datepicker.spec.js
+++ b/test/datepicker/datepicker.spec.js
@@ -361,6 +361,12 @@ describe('Date Picker', function() {
 
             expect(calendar.changeLanguage).toHaveBeenCalled();
         });
+
+        it('`locateTitle` should also be changed when you run `locateLanguage`', function() {
+            datepicker.changeLanguage('ko');
+
+            expect(datepicker._datepickerInput._titles).toEqual(datepicker.getLocaleText().titles);
+        });
     });
 
     describe('events - ', function() {


### PR DESCRIPTION
## `changeLanguage` 메서드를 사용하였지만 format의 형식은 변경된 언어로 반영되지 않음

* 문제
  * MMM-dd 포멧은 en으로 변경시 `12월-06` -> `Dec-06` (이렇게 변경되어야 하는데 한글이 나옴)

* 원인
  * 언어 변경시 input 인스턴스의 _titles 프로퍼티의 텍스트도 함께 변경되어야 하지만 함께 변경안됨

* 해결
  * 언어 변경시 _titles 프로퍼티도 함께 변경해주고 input 내의 표시되는 부분 다시 갱신해주도록 수정